### PR TITLE
Support additional variations of "CHECKSTYLE:OFF" comments

### DIFF
--- a/checkstyle/5amCheckstyle.xml
+++ b/checkstyle/5amCheckstyle.xml
@@ -80,5 +80,23 @@
         <module name="OneStatementPerLine"/>
     </module>
     <module name="Translation"/>
-    <module name="SuppressionCommentFilter"/>
+    <module name="SuppressionCommentFilter">
+        <property name="offCommentFormat" value="CHECKSTYLE\:OFF($|[^\:].*)" />
+        <property name="onCommentFormat" value="CHECKSTYLE\:ON($|[^:].*)" />
+    </module>
+    <module name="SuppressionCommentFilter">
+        <property name="offCommentFormat" value="CHECKSTYLE\:OFF\: ([\w\|]+)" />
+        <property name="onCommentFormat" value="CHECKSTYLE\:ON\: ([\w\|]+)" />
+        <property name="checkFormat" value="$1" />
+    </module>
+    <module name="SuppressWithNearbyCommentFilter">
+        <property name="commentFormat" value="CHECKSTYLE\:IGNORE($|[^\:].*)" />
+        <property name="checkFormat" value=".*" />
+        <property name="influenceFormat" value="1" />
+    </module>
+    <module name="SuppressWithNearbyCommentFilter">
+        <property name="commentFormat" value="CHECKSTYLE\:IGNORE\: ([\w\|]+)" />
+        <property name="checkFormat" value="$1"/>
+        <property name="influenceFormat" value="1" />
+    </module>
 </module>


### PR DESCRIPTION
This maintains support for the style commonly used in files currently:

//CHECKSTYLE:OFF - optional comment here
...
//CHECKSTYLE:ON - optional different comment here

But also adds the following:
Disable a specific rule: //CHECKSTYLE:OFF: CheckstyleRule
Disable checking for the following line: //CHECKSTYLE:IGNORE
Disable a specific rule for the following line: //CHECKSTYLE:IGNORE: CheckstyleRule
