### PR TITLE
BL-8348: exclude GuardLogStatement rule

### DIFF
--- a/pmd/5amPmd-3.5.xml
+++ b/pmd/5amPmd-3.5.xml
@@ -67,13 +67,8 @@
         <exclude name="BeanMembersShouldSerialize" />
     </rule>
 
-    <rule ref="rulesets/java/logging-jakarta-commons.xml" />
-
-    <rule ref="rulesets/java/logging-jakarta-commons.xml/GuardLogStatement">
-	<properties>
-		<property name="guardsMethods" value="isDebugEnabled" />
-		<property name="logLevels" value="debug" />
-	</properties>
+    <rule ref="rulesets/java/logging-jakarta-commons.xml">
+    	<exclude name="GuardLogStatement" />
     </rule>
 
     <rule ref="rulesets/java/logging-java.xml">


### PR DESCRIPTION
Exclude GuardLogStatement rule instead of configuring it to check for debug log statements because there is a GuardDebugLogging rule for that.